### PR TITLE
[SE-3150] add mysql logrotation to playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Whether MySQL should be enabled on startup.
     
 The main my.cnf configuration file and include directory.
 
+    mysql_defaults_file: *default value depends on OS*
+    mysql_logrotate_config_file: *default value depends on OS*
+
+The logrotation configuration file and mysql_defaults_file for mysql logs.
+
     overwrite_global_mycnf: yes
 
 Whether the global my.cnf should be overwritten each time this role is run. Setting this to `no` tells Ansible to only create the `my.cnf` file if it doesn't exist. This should be left at its default value (`yes`) if you'd like to use this role's variables to configure MySQL.

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -70,6 +70,15 @@
     mode: 0640
   when: mysql_log == "" and mysql_log_error != ""
 
+- name: Create logrotate configuration for mysql.
+  file:
+    src: mysql-server
+    dest: "{{ mysql_config_file }}"
+    owner: root
+    group: root
+    mode: 0644
+    force: yes
+
 - name: Ensure MySQL is started and enabled on boot.
   service: "name={{ mysql_daemon }} state=started enabled={{ mysql_enabled_on_startup }}"
   register: mysql_service_configuration

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -47,6 +47,16 @@
     mysql_config_file: "{{ __mysql_config_file }}"
   when: mysql_config_file is not defined
 
+- name: Define mysql_defaults_file:
+  set_fact:
+    mysql_defaults_file: "{{ __mysql_defaults_file }}"
+  when: mysql_defaults_file is not defined
+
+- name: Define mysql_logrotate_config_file:
+  set_fact:
+    mysql_logrotate_config_file: "{{ __mysql_logrotate_config_file }}"
+  when: mysql_logrotate_config_file is not defined
+
 - name: Define mysql_config_include_dir.
   set_fact:
     mysql_config_include_dir: "{{ __mysql_config_include_dir }}"

--- a/templates/mysql-server.j2
+++ b/templates/mysql-server.j2
@@ -1,0 +1,26 @@
+# {{ ansible_managed }}
+
+# - I put everything in one block and added sharedscripts, so that mysql gets
+#   flush-logs'd only once.
+#   Else the binary logs would automatically increase by n times every day.
+# - The error log is obsolete, messages go to syslog now.
+{% if mysql_log == '' %}{{ mysql_log }} {% endif %}/var/log/mysql/*log {
+	daily
+	rotate 7
+	missingok
+	create 640 mysql adm
+	compress
+	sharedscripts
+	postrotate
+		test -x /usr/bin/mysqladmin || exit 0
+		# If this fails, check {{ mysql_defaults_file }}!
+		MYADMIN="/usr/bin/mysqladmin --defaults-file={{ mysql_defaults_file }}"
+		if [ -z "`$MYADMIN ping 2>/dev/null`" ]; then
+		  if killall -q -s0 -umysql mysqld; then
+ 		    exit 1
+		  fi
+		else
+		  $MYADMIN flush-logs
+		fi
+	endscript
+}

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -7,6 +7,8 @@ __mysql_log_error: /var/log/mysql.err
 __mysql_syslog_tag: mysql
 __mysql_pid_file: /run/mysqld/mysqld.pid
 __mysql_config_file: /etc/mysql/my.cnf
+__mysql_defaults_file: /etc/mysql/my.cnf
+__mysql_logrotate_config_file: /etc/logrotate.d/mysql-server
 __mysql_config_include_dir: /etc/mysql/conf.d
 __mysql_socket: /run/mysqld/mysqld.sock
 __mysql_supports_innodb_large_prefix: true

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -9,6 +9,8 @@ __mysql_log_error: /var/log/mysql/mysql.err
 __mysql_syslog_tag: mysql
 __mysql_pid_file: /var/run/mysqld/mysqld.pid
 __mysql_config_file: /etc/mysql/my.cnf
+__mysql_defaults_file: /etc/mysql/debian.cnf
+__mysql_logrotate_config_file: /etc/logrotate.d/mysql-server
 __mysql_config_include_dir: /etc/mysql/conf.d
 __mysql_socket: /var/run/mysqld/mysqld.sock
 __mysql_supports_innodb_large_prefix: true

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -8,6 +8,8 @@ __mysql_log_error: /var/log/mysql.err
 __mysql_syslog_tag: mysql
 __mysql_pid_file: /var/run/mysqld/mysqld.pid
 __mysql_config_file: /etc/my.cnf
+__mysql_defaults_file: /etc/mysql/my.cnf
+__mysql_logrotate_config_file: /etc/logrotate.d/mysql-server
 __mysql_config_include_dir: /etc/my.cnf.d
 __mysql_socket: /var/lib/mysql/mysql.sock
 __mysql_supports_innodb_large_prefix: false

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -11,6 +11,8 @@ __mysql_log_error: /var/log/mariadb/mariadb.log
 __mysql_syslog_tag: mariadb
 __mysql_pid_file: /var/run/mariadb/mariadb.pid
 __mysql_config_file: /etc/my.cnf
+__mysql_defaults_file: /etc/my.cnf
+__mysql_logrotate_config_file: /etc/logrotate.d/mysql-server
 __mysql_config_include_dir: /etc/my.cnf.d
 __mysql_socket: /var/lib/mysql/mysql.sock
 __mysql_supports_innodb_large_prefix: true


### PR DESCRIPTION
Add mysql logrotation config file to ansible to fix logrotation issue in case of a missing file.

**Screenshots**: N/A

**Sandbox URL**: N/A

**Testing instructions**:

_Testing instructions for this would require to provision a new server which does not make sense._

* Read through the code

**Author notes and concerns**:

No further action required on the slave which is built with this role, since I manually adjusted the configuration there.

**Reviewers**
- [ ] @mavidser 