### PR TITLE
chore: upgrade MySQL role to 5.7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -130,3 +130,4 @@ mysql_replication_role: ''
 mysql_replication_master: ''
 # Same keys as `mysql_users` above.
 mysql_replication_user: []
+mysql_replication_gtid: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,3 +24,42 @@
 - include_tasks: databases.yml
 - include_tasks: users.yml
 - include_tasks: replication.yml
+
+# Enable GTID and reconfigure
+- set_fact:
+    mysql_replication_gtid: true
+- name: Copy my.cnf global MySQL configuration.
+  template:
+    src: my.cnf.j2
+    dest: "{{ mysql_config_file }}"
+    owner: root
+    group: root
+    mode: 0644
+    force: "{{ overwrite_global_mycnf }}"
+
+- name: Restart mysql to load config.
+  service:
+    name: mysql
+    state: restarted
+
+- name: Stopslave.
+  mysql_replication:
+    mode: stopslave
+  when: >
+    ((slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Slave is not defined and slave|failed))
+    and (mysql_replication_role == 'slave')
+    and (mysql_replication_master != '')
+    and mysql_replication_user
+
+- name: Changemaster to support GTID replication on the slave.
+  mysql_replication:
+    mode: changemaster
+    master_host: "{{ mysql_replication_master }}"
+    master_user: "{{ mysql_replication_user.name }}"
+    master_password: "{{ mysql_replication_user.password }}"
+    master_auto_position: "1"
+  when: >
+    ((slave.Is_Slave is defined and not slave.Is_Slave) or (slave.Is_Slave is not defined and slave|failed))
+    and (mysql_replication_role == 'slave')
+    and (mysql_replication_master != '')
+    and mysql_replication_user

--- a/tasks/secure-installation.yml
+++ b/tasks/secure-installation.yml
@@ -33,7 +33,7 @@
     ORDER BY (Host='localhost') ASC"
   register: mysql_root_hosts
   changed_when: false
-  check_mode: false
+  check_mode: no
   when: mysql_install_packages | bool or mysql_root_password_update
 
 # Note: We do not use mysql_user for this operation, as it doesn't always update
@@ -73,7 +73,7 @@
   command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'
   register: mysql_anonymous_hosts
   changed_when: false
-  check_mode: false
+  check_mode: no
 
 - name: Remove anonymous MySQL users.
   mysql_user:

--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -66,7 +66,19 @@ binlog_ignore_db = {{ db.name }}
 read_only
 relay-log = relay-bin
 relay-log-index = relay-bin.index
+{% if mysql_replication_gtid | bool %}
+log_bin = mysql-bin
+log-bin-index = mysql-bin.index
+binlog_format = {{mysql_binlog_format}}
 {% endif %}
+{% endif %}
+
+{% if mysql_replication_gtid | bool %}
+gtid_mode=ON
+enforce_gtid_consistency=ON
+log-slave-updates
+{% endif %}
+
 {% endif %}
 
 # Disabling symbolic-links is recommended to prevent assorted security risks


### PR DESCRIPTION
## Description

Contains the changes made in https://github.com/open-craft/ansible-role-mysql/tree/0x29a/bb4048-mysql5.7 which have been deployed to production.

## Supporting information

- https://tasks.opencraft.com/browse/SE-5440
- [BB-4049 comment](https://tasks.opencraft.com/browse/BB-4049?focusedCommentId=214330&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-214330)

## Testing instructions

The changes have already been deployed to the following servers:

- mysql-im-3-master.net.opencraft.hosting
- mysql-im-3-slave1.net.opencraft.hosting
- mysql-im-3-slave2.net.opencraft.hosting

Check that my.cnf has the changes mentioned.